### PR TITLE
chore(ci): adiciona workflows para commits e pr e teste do product service

### DIFF
--- a/.github/workflows/ci-commits.yml
+++ b/.github/workflows/ci-commits.yml
@@ -1,0 +1,37 @@
+name: CI on Commits
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_BRANCH: main
+    steps:
+      - name: Checkout do repositório
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Trocar para a branch específica (atividade frequente)
+        run: |
+          git fetch origin ${{ env.TARGET_BRANCH }} --depth=1
+          git checkout ${{ env.TARGET_BRANCH }}
+
+      - name: Instalar Java 17 (Temurin) + cache Maven
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Baixar dependências (offline-ready)
+        run: mvn -B -q -DskipTests dependency:go-offline
+
+      - name: Compilar
+        run: mvn -B -q -DskipTests package
+
+      - name: Executar testes
+        run: mvn -B test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,35 @@
+name: CI on Pull Requests
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do repositório
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Trocar para a branch do PR (atividade frequente)
+        run: |
+          git fetch origin "${{ github.event.pull_request.head.ref }}" --depth=1
+          git checkout "${{ github.event.pull_request.head.ref }}"
+
+      - name: Instalar Java 17 (Temurin) + cache Maven
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Baixar dependências (offline-ready)
+        run: mvn -B -q -DskipTests dependency:go-offline
+
+      - name: Compilar
+        run: mvn -B -q -DskipTests package
+
+      - name: Executar testes
+        run: mvn -B test

--- a/src/test/java/com/example/product_api/service/ProductServiceTest.java
+++ b/src/test/java/com/example/product_api/service/ProductServiceTest.java
@@ -1,0 +1,84 @@
+package com.example.product_api.service;
+
+import com.example.product_api.domain.Product;
+import com.example.product_api.dto.ProductRequest;
+import com.example.product_api.dto.ProductResponse;
+import com.example.product_api.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductService service;
+
+    @Captor
+    private ArgumentCaptor<Product> productCaptor;
+
+
+    @Test
+    void findAll_deveRetornarListaMapeadaParaResponse() {
+        Product p1 = mock(Product.class);
+        when(p1.getId()).thenReturn(10L);
+        when(p1.getName()).thenReturn("Laptop");
+        when(p1.getCategory()).thenReturn("Eletronic");
+
+        Product p2 = mock(Product.class);
+        when(p2.getId()).thenReturn(11L);
+        when(p2.getName()).thenReturn("Mouse Gamer");
+        when(p2.getCategory()).thenReturn("Periferic");
+
+        when(productRepository.findAll()).thenReturn(List.of(p1, p2));
+
+        List<ProductResponse> result = service.findAll();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).id()).isEqualTo(10L);
+        assertThat(result.get(0).name()).isEqualTo("Laptop");
+        assertThat(result.get(0).category()).isEqualTo("Eletronic");
+
+        assertThat(result.get(1).id()).isEqualTo(11L);
+        assertThat(result.get(1).name()).isEqualTo("Mouse Gamer");
+        assertThat(result.get(1).category()).isEqualTo("Periferic");
+
+        verify(productRepository, times(1)).findAll();
+        verifyNoMoreInteractions(productRepository);
+    }
+
+    @Test
+    void save_deveSalvarEDevolverResponseComIdGerado() {
+        ProductRequest req = new ProductRequest("Keyboard", "Periferic");
+
+        Product saved = mock(Product.class);
+        when(saved.getId()).thenReturn(42L);
+        when(productRepository.save(any(Product.class))).thenReturn(saved);
+
+        ProductResponse resp = service.save(req);
+
+        assertThat(resp.id()).isEqualTo(42L);
+        assertThat(resp.name()).isEqualTo("Keyboard");
+        assertThat(resp.category()).isEqualTo("Periferic");
+
+        verify(productRepository).save(productCaptor.capture());
+        Product enviado = productCaptor.getValue();
+        assertThat(enviado.getName()).isEqualTo("Keyboard");
+        assertThat(enviado.getCategory()).isEqualTo("Periferic");
+
+        verifyNoMoreInteractions(productRepository);
+    }
+}


### PR DESCRIPTION
## O que foi feito
- Adicionados dois workflows do GitHub Actions:
  - ci-commits.yml: roda em eventos de commit (push)
  - ci-pr.yml: roda em eventos de pull_request
- Ambos: checkout do repo, troca explícita de branch, setup do Java 17, download de dependências, build e testes
- Adicionado teste do service para garantir execução de testes

## Como validar
- Fazer push em qualquer branch e ver o workflow de commits rodar
- Abrir/atualizar um PR para main e ver o workflow de PR rodar

## Checklist
- [x] Build passa
- [x] Teste mínimo executa
- [x] Troca de branch explícita em ambos os workflows
